### PR TITLE
Missing total argument on transformDeprecations method

### DIFF
--- a/app/Http/Transformers/DepreciationsTransformer.php
+++ b/app/Http/Transformers/DepreciationsTransformer.php
@@ -9,14 +9,14 @@ use Illuminate\Database\Eloquent\Collection;
 
 class DepreciationsTransformer
 {
-    public function transformDepreciations(Collection $depreciations)
+    public function transformDepreciations(Collection $depreciations, $total)
     {
         $array = [];
         foreach ($depreciations as $depreciation) {
             $array[] = self::transformDepreciation($depreciation);
         }
 
-        return (new DatatablesTransformer)->transformDatatables($array);
+        return (new DatatablesTransformer)->transformDatatables($array, $total);
     }
 
     public function transformDepreciation(Depreciation $depreciation)
@@ -27,8 +27,7 @@ class DepreciationsTransformer
             'months' => $depreciation->months.' '.trans('general.months'),
             'depreciation_min' => $depreciation->depreciation_min,
             'created_at' => Helper::getFormattedDateObject($depreciation->created_at, 'datetime'),
-            'updated_at' => Helper::getFormattedDateObject($depreciation->updated_at, 'datetime'),
-            'depreciation_min' =>($depreciation->depreciation_min),
+            'updated_at' => Helper::getFormattedDateObject($depreciation->updated_at, 'datetime')
         ];
 
         $permissions_array['available_actions'] = [


### PR DESCRIPTION
Removed duplicate array key on transformDeprecation method

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context, providing screenshots where practical. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* PHP version:
* MySQL version
* Webserver version
* OS version


# Checklist:

- [ ] I have read the Contributing documentation available here: https://snipe-it.readme.io/docs/contributing-overview
- [ ] I have formatted this PR according to the project guidelines: https://snipe-it.readme.io/docs/contributing-overview#pull-request-guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
